### PR TITLE
Modifying 1st floor labyrinth chances

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ Missing HUD 2 has the below dependencies:
   * [SOIL2](https://bitbucket.org/SpartanJ/soil2)
   * [Boost.Interprocess](http://www.boost.org/doc/libs/1_59_0/doc/html/interprocess.html)
   * [Google's Protobuf](https://github.com/google/protobuf)
-  
+
 It uses the CMake build system to compile.
 The easiest Windows MinGW environment to compile it on is the MSYS2 enviroment.

--- a/src/dll/AfterbirthMemReader.cpp
+++ b/src/dll/AfterbirthMemReader.cpp
@@ -259,9 +259,8 @@ float AfterbirthMemReader::GetDealDoorChance()
     int current_floor = *((int*)player_manager_inst);
     int labyrinth_flag = *((int*)((DWORD)player_manager_inst + AB_PLAYER_MANAGER_CURSE_FLAGS));    // Need to take into account whether the floor is a labyrinth cursed floor
     current_floor_ = current_floor;
-    if (labyrinth_flag == AB_LABYRINTH_CURSE)
-        ++current_floor_;
-    if (current_floor_ == 1 || current_floor_ > 8)    // In-eligible for natural deal on these floors (even with Goat Head)
+
+    if ((current_floor_ == 1 && labyrinth_flag != AB_LABYRINTH_CURSE) || current_floor_ > 8)    // In-eligible for natural deal on these floors (even with Goat Head)
         return 0.0f;
 
     DWORD player = GetPlayerMemAddr();

--- a/src/dll/RebirthMemReader.cpp
+++ b/src/dll/RebirthMemReader.cpp
@@ -258,9 +258,7 @@ float RebirthMemReader::GetDealDoorChance()
     int current_floor = *((int*)player_manager_inst);
     int labyrinth_flag = *((int*)((DWORD)player_manager_inst + RB_PLAYER_MANAGER_CURSE_FLAGS));    // Need to take into account whether the floor is a labyrinth cursed floor
     current_floor_ = current_floor;
-    if (labyrinth_flag == RB_LABYRINTH_CURSE)
-        ++current_floor_;
-    if (current_floor_ == 1 || current_floor_ > 8)    // In-eligible for natural deal on these floors (even with Goat Head)
+    if ((current_floor_ == 1 && labyrinth_flag != RB_LABYRINTH_CURSE) || current_floor_ > 8)    // In-eligible for natural deal on these floors (even with Goat Head)
         return 0.0f;
 
     DWORD player = GetPlayerMemAddr();


### PR DESCRIPTION
This PR aims to fix #46 , where the use of a ??? pill on the first floor overrode the labyrinth curse's 100% deal chance. I think this ought to be fixed by not incrementing the floor level when checking curses initially.